### PR TITLE
Add bulk cell activation with bounds validation

### DIFF
--- a/rust/game-of-life-engine/src/lib.rs
+++ b/rust/game-of-life-engine/src/lib.rs
@@ -61,34 +61,43 @@ impl LifeEngine {
         engine
     }
 
-    pub fn activate_cells(&mut self, cells: HashSet<Cell>) {
+    pub fn activate_cells(&mut self, cells: &[Cell]) -> Result<(), String> {
+        let any_out_of_bounds = cells.iter().any(|c| self.is_cell_within_bounds(c));
+        if any_out_of_bounds {
+            return Err(String::from("some cells out of bounds"))
+        }
         self.alive_cells.reserve(cells.len());
         self.potential_cells.reserve(cells.len() * 8);
         for cell in cells {
             self.do_activate_cell(cell);
         }
+        Ok(())
     }
 
-    pub fn activate_cell(&mut self, x: u32, y: u32) {
+    pub fn activate_cell(&mut self, x: u32, y: u32) -> Result<(), String> {
         let cell = Cell::new(x, y);
-        self.do_activate_cell(cell);
+        if !(self.is_cell_within_bounds(&cell)) {
+            return Err(String::from("cell out of bounds"));
+        }
+        self.do_activate_cell(&cell);
+        Ok(())
     }
 
-    fn do_activate_cell(&mut self, cell: Cell) {
-        if self.is_cell_within_bounds(&cell) {
-            self.alive_cells.insert(cell.clone());
-            self.potential_cells.insert(cell.clone());
-            let mut neighbours = Vec::with_capacity(8);
-            self.get_neighbours(&cell, &mut neighbours);
-            for neighbour in neighbours {
-                self.potential_cells.insert(neighbour);
-            }
+    fn do_activate_cell(&mut self, cell: &Cell) {
+        self.alive_cells.insert(cell.clone());
+        self.potential_cells.insert(cell.clone());
+        let mut neighbours = Vec::with_capacity(8);
+        self.get_neighbours(&cell, &mut neighbours);
+        for neighbour in neighbours {
+            self.potential_cells.insert(neighbour);
         }
     }
 
     pub fn next(&mut self) {
-        let mut alive_cells_next: FxHashSet<Cell> =
-            FxHashSet::with_capacity_and_hasher(self.alive_cells.capacity(), FxBuildHasher::default());
+        let mut alive_cells_next: FxHashSet<Cell> = FxHashSet::with_capacity_and_hasher(
+            self.alive_cells.capacity(),
+            FxBuildHasher::default(),
+        );
         let mut potential_cells_next: FxHashSet<Cell> = FxHashSet::with_capacity_and_hasher(
             self.potential_cells.capacity(),
             FxBuildHasher::default(),
@@ -146,7 +155,7 @@ impl LifeEngine {
         for _ in 0..amount_to_generate {
             let x = rng.random_range(top_left.x..bottom_right.x + 1);
             let y = rng.random_range(top_left.y..bottom_right.y + 1);
-            self.activate_cell(x, y);
+            let _ = self.activate_cell(x, y);
         }
     }
 

--- a/rust/game-of-life-ffi/src/lib.rs
+++ b/rust/game-of-life-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::hash_set::Iter;
+use std::collections::HashSet;
 use game_of_life_engine::{Cell, LifeEngine};
 
 /* ===== C-compatible FFI surface for C#/PInvoke ===== */
@@ -32,7 +33,16 @@ pub extern "C" fn engine_next(ptr: *mut LifeEngine) {
 #[unsafe(no_mangle)]
 pub extern "C" fn engine_activate_cell(ptr: *mut LifeEngine, x: u32, y: u32) {
     if let Some(engine) = unsafe { ptr.as_mut() } {
-        engine.activate_cell(x, y);
+        let _ = engine.activate_cell(x, y);
+    }
+}
+
+// Activate a set of cells.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_activate_cells(ptr: *mut LifeEngine, cells: *const Cell, count: usize) {
+    if let Some(engine) = unsafe { ptr.as_mut() } {
+        let cells_slice = unsafe { std::slice::from_raw_parts(cells, count) };
+        let _ =engine.activate_cells(cells_slice);
     }
 }
 

--- a/rust/game-of-life-wasm/src/lib.rs
+++ b/rust/game-of-life-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use game_of_life_engine::{Cell, LifeEngine};
-use js_sys::{Function, Number};
+use js_sys::{Array, Function, Number, Uint32Array};
 use wasm_bindgen::prelude::*;
 
 /* ===== WASM surface for JS/TS ===== */
@@ -27,8 +27,22 @@ impl LifeEngineWrapper {
 
     // Activate a cell at (x, y).
     #[wasm_bindgen]
-    pub fn activate_cell(&mut self, x: u32, y: u32) {
-        self.engine.activate_cell(x, y);
+    pub fn activate_cell(&mut self, x: u32, y: u32) -> Result<(), String> {
+        self.engine.activate_cell(x, y)
+    }
+
+    #[wasm_bindgen]
+    pub fn activate_cells(&mut self, cells_x: Uint32Array, cells_y: Uint32Array) -> Result<(), String> {
+        if cells_x.length() != cells_y.length() {
+            return Err(String::from("cell arrays must have the same length"));
+        }
+        let mut cells = Vec::with_capacity(cells_x.length() as usize);
+        for i in 0..cells_x.length() {
+            let x = cells_x.get_index(i);
+            let y = cells_y.get_index(i);
+            cells.push(Cell::new(x, y));
+        }
+        self.engine.activate_cells(&cells)
     }
 
     // Generate a random square of cells.


### PR DESCRIPTION
- Introduced `activate_cells` method in WASM, engine, and FFI layers for activating multiple cells at once.
- Added boundary checks and error handling for cell activation methods to prevent out-of-bound operations.
- Refactored `do_activate_cell` to accept cell references for improved efficiency.